### PR TITLE
feat: Enable Claude Code Review to run monorepo tests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,8 +79,8 @@ jobs:
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          # Allow Claude to run tests and linting for both backend and frontend
+          allowed_tools: "Bash(cd backend && uv run pytest:*),Bash(cd backend && uv run ruff check:*),Bash(cd backend && uv run mypy:*),Bash(cd frontend && npm run type-check:*),Bash(cd frontend && npm run lint:*),Bash(cd frontend && npm run build:*)"
           
           # Optional: Skip review for certain conditions
           # if: |


### PR DESCRIPTION
## Summary
Enable Claude Code Review workflow to run tests and linting for both backend and frontend in the monorepo structure.

**Based on PR #28** - This PR should be merged after the monorepo restructuring is complete.

## Changes
- Add `allowed_tools` configuration to [.github/workflows/claude-code-review.yml](.github/workflows/claude-code-review.yml)
- Enable Claude to validate code changes by running tests during PR reviews

## Allowed Tools

**Backend:**
- `cd backend && uv run pytest` - Run Python tests
- `cd backend && uv run ruff check` - Lint Python code
- `cd backend && uv run mypy` - Type check Python code

**Frontend:**
- `cd frontend && npm run type-check` - TypeScript validation
- `cd frontend && npm run lint` - ESLint
- `cd frontend && npm run build` - Next.js build

## Benefits
- Claude can now run tests during code reviews to validate changes
- Supports the monorepo structure with separate backend/frontend paths
- Helps catch issues earlier in the review process

## Dependencies
- Requires PR #28 (monorepo restructuring) to be merged first

🤖 Generated with [Claude Code](https://claude.com/claude-code)