### PR TITLE
Add React.memo to chart components for performance

### DIFF
--- a/frontend/components/charts/cumulative-comparison-chart.tsx
+++ b/frontend/components/charts/cumulative-comparison-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import {
   BarChart,
   Bar,
@@ -16,23 +17,30 @@ interface CumulativeComparisonChartProps {
   data: Array<Record<string, any>>;
 }
 
-export function CumulativeComparisonChart({ data }: CumulativeComparisonChartProps) {
-  const chartData = data.map((row) => ({
-    year: `Year ${row.year || 0}`,
-    startup: row.startup_monthly_salary || 0,
-    currentJob: row.current_job_monthly_salary || 0,
-    opportunityCost: row.cumulative_opportunity_cost || 0,
-  }));
+// Format currency with compact notation (e.g., SAR 10K)
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat("en-SA", {
+    style: "currency",
+    currency: "SAR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+    notation: "compact",
+  }).format(value);
+};
 
-  const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat("en-SA", {
-      style: "currency",
-      currency: "SAR",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-      notation: "compact",
-    }).format(value);
-  };
+export const CumulativeComparisonChart = React.memo(function CumulativeComparisonChart({
+  data
+}: CumulativeComparisonChartProps) {
+  // Memoize the data transformation to avoid recalculating on every render
+  const chartData = React.useMemo(() =>
+    data.map((row) => ({
+      year: `Year ${row.year || 0}`,
+      startup: row.startup_monthly_salary || 0,
+      currentJob: row.current_job_monthly_salary || 0,
+      opportunityCost: row.cumulative_opportunity_cost || 0,
+    })),
+    [data]
+  );
 
   return (
     <ResponsiveContainer width="100%" height={400}>
@@ -80,4 +88,6 @@ export function CumulativeComparisonChart({ data }: CumulativeComparisonChartPro
       </BarChart>
     </ResponsiveContainer>
   );
-}
+});
+
+CumulativeComparisonChart.displayName = "CumulativeComparisonChart";

--- a/frontend/components/charts/monte-carlo-visualizations.tsx
+++ b/frontend/components/charts/monte-carlo-visualizations.tsx
@@ -24,7 +24,19 @@ interface MonteCarloVisualizationsProps {
   simulatedValuations: number[];
 }
 
-export function MonteCarloVisualizations({
+// Format currency with compact notation (e.g., SAR 10K)
+// Moved outside component to avoid recreation on each render
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat("en-SA", {
+    style: "currency",
+    currency: "SAR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+    notation: "compact",
+  }).format(value);
+};
+
+export const MonteCarloVisualizations = React.memo(function MonteCarloVisualizations({
   netOutcomes,
   simulatedValuations,
 }: MonteCarloVisualizationsProps) {
@@ -73,7 +85,6 @@ export function MonteCarloVisualizations({
   }, [netOutcomes]);
 
   // Prepare ECDF data
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization
   const ecdfData = React.useMemo(() => {
     const sorted = [...netOutcomes].sort((a, b) => a - b);
     return sorted.map((value, index) => ({
@@ -103,16 +114,6 @@ export function MonteCarloVisualizations({
       { name: "Max", value: stats.max },
     ];
   }, [stats]);
-
-  const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat("en-SA", {
-      style: "currency",
-      currency: "SAR",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-      notation: "compact",
-    }).format(value);
-  };
 
   return (
     <Card>
@@ -522,4 +523,6 @@ export function MonteCarloVisualizations({
       </CardContent>
     </Card>
   );
-}
+});
+
+MonteCarloVisualizations.displayName = "MonteCarloVisualizations";

--- a/frontend/components/charts/opportunity-cost-chart.tsx
+++ b/frontend/components/charts/opportunity-cost-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import {
   LineChart,
   Line,
@@ -17,22 +18,29 @@ interface OpportunityCostChartProps {
   data: Array<Record<string, any>>;
 }
 
-export function OpportunityCostChart({ data }: OpportunityCostChartProps) {
-  const chartData = data.map((row) => ({
-    year: `Year ${row.year || 0}`,
-    opportunityCost: row.cumulative_opportunity_cost || 0,
-    monthlySurplus: (row.monthly_surplus || 0) * 12, // Convert to annual
-  }));
+// Format currency with compact notation (e.g., SAR 10K)
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat("en-SA", {
+    style: "currency",
+    currency: "SAR",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+    notation: "compact",
+  }).format(value);
+};
 
-  const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat("en-SA", {
-      style: "currency",
-      currency: "SAR",
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-      notation: "compact",
-    }).format(value);
-  };
+export const OpportunityCostChart = React.memo(function OpportunityCostChart({
+  data
+}: OpportunityCostChartProps) {
+  // Memoize the data transformation to avoid recalculating on every render
+  const chartData = React.useMemo(() =>
+    data.map((row) => ({
+      year: `Year ${row.year || 0}`,
+      opportunityCost: row.cumulative_opportunity_cost || 0,
+      monthlySurplus: (row.monthly_surplus || 0) * 12, // Convert to annual
+    })),
+    [data]
+  );
 
   return (
     <ResponsiveContainer width="100%" height={400}>
@@ -87,4 +95,6 @@ export function OpportunityCostChart({ data }: OpportunityCostChartProps) {
       </LineChart>
     </ResponsiveContainer>
   );
-}
+});
+
+OpportunityCostChart.displayName = "OpportunityCostChart";


### PR DESCRIPTION
## Summary
- Wrapped all chart components with `React.memo` to prevent unnecessary re-renders
- Added `useMemo` for data transformations inside components
- Moved `formatCurrency` functions outside components (pure functions)
- Added `displayName` for better React DevTools debugging

## Problem
Chart components were re-rendering on every parent state change, even when their data hadn't changed. This caused unnecessary work, especially for the complex Monte Carlo visualizations with 7 tabs.

## Solution
`React.memo` performs a shallow comparison of props. If the `data` array reference hasn't changed, the component skips rendering entirely.

```typescript
// Before - renders on every parent update
export function CumulativeComparisonChart({ data }) { ... }

// After - only renders when data changes
export const CumulativeComparisonChart = React.memo(function CumulativeComparisonChart({ data }) {
  const chartData = React.useMemo(() => /* transform */, [data]);
  ...
});
```

## Files Changed
| File | Changes |
|------|---------|
| `cumulative-comparison-chart.tsx` | +React.memo, +useMemo, moved formatCurrency out |
| `opportunity-cost-chart.tsx` | +React.memo, +useMemo, moved formatCurrency out |
| `monte-carlo-visualizations.tsx` | +React.memo, moved formatCurrency out |

## Test plan
- [x] Build passes (`npm run build`)
- [x] ESLint passes on modified files
- [ ] Manual testing: Verify charts still render correctly
- [ ] Manual testing: Confirm no visual regressions in Monte Carlo tabs

## Closes
Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)