### PR TITLE
Disable Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,18 +1,21 @@
 name: Claude Code Review
 
+# Disabled: Workflow temporarily disabled to reduce CI noise
+# To re-enable, uncomment the pull_request trigger below
 on:
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - "backend/**/*.py"
-      - "backend/pyproject.toml"
-      - "backend/tests/**"
-      - "frontend/**/*.ts"
-      - "frontend/**/*.tsx"
-      - "frontend/**/*.js"
-      - "frontend/**/*.jsx"
-      - "frontend/package.json"
-      - ".github/workflows/**"
+  workflow_dispatch: # Manual trigger only
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   paths:
+  #     - "backend/**/*.py"
+  #     - "backend/pyproject.toml"
+  #     - "backend/tests/**"
+  #     - "frontend/**/*.ts"
+  #     - "frontend/**/*.tsx"
+  #     - "frontend/**/*.js"
+  #     - "frontend/**/*.jsx"
+  #     - "frontend/package.json"
+  #     - ".github/workflows/**"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
- Change workflow trigger from automatic (`pull_request`) to manual (`workflow_dispatch`)
- Reduces CI noise on every PR
- Workflow can still be triggered manually from the Actions tab when needed

## To re-enable
Uncomment the `pull_request` trigger in `.github/workflows/claude-code-review.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)