### PR TITLE
Improve WebSocket error handling specificity

### DIFF
--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -337,16 +337,23 @@ export function useMonteCarloWebSocket(): MonteCarloWSResult {
             ws.close();
             break;
         }
-      } catch {
-        setError("Failed to parse server message");
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          console.error("Invalid JSON from server:", event.data);
+          setError("Server sent invalid response format");
+        } else {
+          console.error("Error processing message:", e);
+          setError("Failed to process server message");
+        }
+        // Don't close connection on parse error - server may recover
+        // Only mark as not running to allow retry
         setIsRunning(false);
-        setIsConnected(false);
-        ws.close();
       }
     };
 
-    ws.onerror = () => {
-      setError("WebSocket connection error");
+    ws.onerror = (event) => {
+      console.error("WebSocket error:", event);
+      setError("Connection error - please try again");
       setIsRunning(false);
       setIsConnected(false);
     };


### PR DESCRIPTION
Improve error handling in the WebSocket client for Monte Carlo simulations.

## Summary
- Distinguish between different error types (JSON parse vs other errors)
- Add console logging for debugging
- Provide specific, user-friendly error messages
- Don't close connection on recoverable errors

## Changes in frontend/lib/api-client.ts
- catch block: Handle SyntaxError specifically vs other errors
- Error logging: Add console.error() calls for all errors  
- Error messages: 
  - JSON parse: "Server sent invalid response format"
  - Other: "Failed to process server message"
  - Connection: "Connection error - please try again"
- Connection handling: Don't close WebSocket on parse errors
- ws.onerror: Add event parameter for better logging

## Acceptance Criteria (from #68)
- [x] Different error messages for different error types
- [x] Errors logged to console for debugging
- [x] Connection not closed on recoverable errors
- [x] User sees helpful error messages

Closes #68