### PR TITLE
Fix mypy type errors in get_random_variates_pert

### DIFF
--- a/backend/src/worth_it/calculations.py
+++ b/backend/src/worth_it/calculations.py
@@ -486,7 +486,7 @@ def calculate_npv(
 
 
 def get_random_variates_pert(
-    num_simulations: int, config: dict, default_val: float
+    num_simulations: int, config: dict | None, default_val: float
 ) -> np.ndarray:
     """Generates random numbers based on a PERT distribution."""
     if not config:
@@ -746,7 +746,7 @@ def run_monte_carlo_simulation_iterative(
     """
     sim_params = {}
     sim_params["exit_year"] = get_random_variates_pert(
-        num_simulations, sim_param_configs.get("exit_year"), base_params["exit_year"]  # type: ignore[arg-type]
+        num_simulations, sim_param_configs.get("exit_year"), base_params["exit_year"]
     ).astype(int)
 
     if "yearly_valuation" in sim_param_configs:
@@ -777,11 +777,11 @@ def run_monte_carlo_simulation_iterative(
 
     sim_params["salary_growth"] = get_random_variates_pert(
         num_simulations,
-        sim_param_configs.get("salary_growth"),  # type: ignore[arg-type]
+        sim_param_configs.get("salary_growth"),
         base_params["current_job_salary_growth_rate"],
     )
     sim_params["dilution"] = get_random_variates_pert(
-        num_simulations, sim_param_configs.get("dilution"), np.nan  # type: ignore[arg-type]
+        num_simulations, sim_param_configs.get("dilution"), np.nan
     )
 
     net_outcomes_list: list[float] = []


### PR DESCRIPTION
## Summary
Fix mypy type errors that are causing backend-lint to fail across multiple PRs.

## Changes
- Update `get_random_variates_pert` function signature to accept `dict | None`
- Remove `# type: ignore[arg-type]` comments that were suppressing the errors

The function already handles `None` values correctly with an early return,
so the type signature should reflect that.

## Test plan
- [x] `uv run mypy src/worth_it/calculations.py src/worth_it/api.py src/worth_it/models.py --ignore-missing-imports` passes
- [x] `uv run pyright src/worth_it/calculations.py src/worth_it/api.py src/worth_it/models.py` - 0 errors
- [x] All 20 calculation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)