### PR TITLE
Fix npm run lint script to include target directory

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Fixed the `npm run lint` script in `frontend/package.json` which was missing the target directory argument.

## Changes

- Updated lint script from `"eslint"` to `"eslint ."` to actually lint files in the frontend directory
- Verified the script works correctly by running `npm run lint`

## Testing

- Ran `npm run lint` successfully - it now properly lints all files in the frontend directory
- Pre-commit hooks passed

## Issue

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)