### PR TITLE
Extract duplicated formatCurrency function into shared utility

### DIFF
--- a/frontend/components/charts/monte-carlo/utils.ts
+++ b/frontend/components/charts/monte-carlo/utils.ts
@@ -2,15 +2,10 @@
  * Shared utility functions for Monte Carlo visualizations
  */
 
-export function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-SA", {
-    style: "currency",
-    currency: "SAR",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-    notation: "compact",
-  }).format(value);
-}
+import { formatCurrencyCompact } from "@/lib/format-utils";
+
+// Re-export for backward compatibility
+export { formatCurrencyCompact as formatCurrency };
 
 /**
  * Common chart tooltip style configuration


### PR DESCRIPTION
## Summary
Closes #55

This PR extracts the duplicated `formatCurrency` function that was defined across 4 different files into a single shared utility module.

## Changes
- Created `frontend/lib/format-utils.ts` with two export functions:
  - `formatCurrency`: Full notation (e.g., "SAR 10,000")
  - `formatCurrencyCompact`: Compact notation (e.g., "SAR 10K")
- Updated `scenario-results.tsx` to import and use the shared `formatCurrency`
- Updated `opportunity-cost-chart.tsx` to import and use `formatCurrencyCompact`
- Updated `cumulative-comparison-chart.tsx` to import and use `formatCurrencyCompact`
- Updated `monte-carlo/utils.ts` to re-export `formatCurrencyCompact` as `formatCurrency` for backward compatibility with existing monte-carlo components

## Test Plan
- [x] All TypeScript type-checking passes (`npm run type-check`)
- [x] All ESLint checks pass (`npm run lint`)
- [x] Pre-commit hooks pass
- [x] No functional changes - only code organization

## Benefits
- Eliminates code duplication (DRY principle)
- Single source of truth for currency formatting logic
- Easier to maintain and modify formatting in the future
- Two named variants make intent clearer at call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)