### PR TITLE
feat: add notes/comments to saved scenarios (#161)

### DIFF
--- a/frontend/components/results/scenario-results.tsx
+++ b/frontend/components/results/scenario-results.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 
 interface ScenarioResultsProps {
   results: StartupScenarioResponse;
@@ -43,6 +44,7 @@ interface ScenarioResultsProps {
 export function ScenarioResults({ results, isLoading, monteCarloContent, globalSettings, currentJob, equityDetails }: ScenarioResultsProps) {
   const [showSaveDialog, setShowSaveDialog] = React.useState(false);
   const [scenarioName, setScenarioName] = React.useState("");
+  const [scenarioNotes, setScenarioNotes] = React.useState("");
 
   if (isLoading) {
     return (
@@ -68,6 +70,7 @@ export function ScenarioResults({ results, isLoading, monteCarloContent, globalS
     const scenarioData: ScenarioData = {
       name: scenarioName.trim(),
       timestamp: new Date().toISOString(),
+      notes: scenarioNotes.trim() || undefined,
       globalSettings: {
         exitYear: globalSettings.exit_year,
       },
@@ -111,6 +114,7 @@ export function ScenarioResults({ results, isLoading, monteCarloContent, globalS
       });
       setShowSaveDialog(false);
       setScenarioName("");
+      setScenarioNotes("");
     } catch (error) {
       console.error("Failed to save scenario:", error);
       toast.error("Failed to save scenario", {
@@ -455,12 +459,26 @@ export function ScenarioResults({ results, isLoading, monteCarloContent, globalS
                 className="font-mono"
               />
             </div>
+            <div className="space-y-2">
+              <Label htmlFor="scenario-notes" className="font-mono text-sm">
+                Notes <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Textarea
+                id="scenario-notes"
+                placeholder="Add any notes or comments about this scenario..."
+                value={scenarioNotes}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setScenarioNotes(e.target.value)}
+                className="font-mono min-h-[80px] resize-none"
+                rows={3}
+              />
+            </div>
           </div>
           <DialogFooter>
             <Button
               onClick={() => {
                 setShowSaveDialog(false);
                 setScenarioName("");
+                setScenarioNotes("");
               }}
               variant="outline"
               className="font-mono"

--- a/frontend/components/ui/textarea.tsx
+++ b/frontend/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/frontend/lib/export-utils.ts
+++ b/frontend/lib/export-utils.ts
@@ -19,6 +19,7 @@ import autoTable from "jspdf-autotable";
 export interface ScenarioData {
   name: string;
   timestamp: string;
+  notes?: string;
   globalSettings: {
     exitYear: number;
   };
@@ -188,6 +189,28 @@ export function deleteScenario(timestamp: string): void {
   } catch (error) {
     console.error("Failed to delete scenario from localStorage:", error);
     throw new Error("Failed to delete scenario. Storage may be unavailable.");
+  }
+}
+
+/**
+ * Update notes for a saved scenario.
+ * Returns true if the scenario was found and updated, false otherwise.
+ */
+export function updateScenarioNotes(timestamp: string, notes: string | undefined): boolean {
+  try {
+    const scenarios = getSavedScenarios();
+    const index = scenarios.findIndex((s) => s.timestamp === timestamp);
+
+    if (index === -1) {
+      return false;
+    }
+
+    scenarios[index].notes = notes;
+    localStorage.setItem("worth_it_scenarios", JSON.stringify(scenarios));
+    return true;
+  } catch (error) {
+    console.error("Failed to update scenario notes:", error);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds the ability to attach notes/comments to saved scenarios for better organization and comparison context.

### Changes
- **ScenarioData Interface**: Added optional `notes` field
- **Save Dialog**: Added textarea for entering notes when saving scenarios
- **Scenario Manager**: 
  - Display notes with StickyNote icon in scenario list
  - Added edit notes button (Pencil icon)
  - Added edit notes dialog for updating existing notes
- **Core Functions**: Added `updateScenarioNotes()` function for editing notes
- **UI Component**: Added shadcn Textarea component

### Screenshots
The notes appear below the timestamp in each scenario card, with a subtle background and italic styling.

## Test Plan
- [x] All 363 unit tests passing
- [x] TypeScript type-check passes
- [x] ESLint passes (no new warnings)
- [ ] Manual testing: Save scenario with notes
- [ ] Manual testing: Save scenario without notes
- [ ] Manual testing: Edit notes on existing scenario
- [ ] Manual testing: Notes preserved when duplicating scenario

Resolves #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)