### PR TITLE
fix(ui): improve layout spacing for better visual separation

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -252,7 +252,7 @@ export default function Home() {
     <AppShell
       sidebar={
         appMode === "employee" ? (
-          <div className="space-y-4">
+          <div className="space-y-6">
             <ExampleLoader />
             <FormCompletionSummary status={formStatus} />
             <GlobalSettingsFormComponent value={globalSettings} onChange={setGlobalSettings} />

--- a/frontend/components/layout/app-shell.tsx
+++ b/frontend/components/layout/app-shell.tsx
@@ -33,7 +33,7 @@ function AppShellContent({ sidebar, children }: AppShellProps) {
           </Sheet>
         )}
 
-        <main className="flex-1 overflow-auto page-enter">{children}</main>
+        <main className="flex-1 overflow-auto page-enter md:px-6">{children}</main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Improved visual spacing throughout the application for better readability and aesthetics.

## Changes

**Sidebar cards (`app/page.tsx`):**
- Increased spacing between form cards from `space-y-4` (16px) to `space-y-6` (24px)
- Cards now have more breathing room between them

**Main content (`components/layout/app-shell.tsx`):**
- Added `md:px-6` (24px horizontal padding) to main content area
- Creates visible gap between sidebar border and main content
- Creates visible gap from right viewport edge
- Only applies on desktop (md+) where sidebar is visible

## Before/After

The main content was stuck directly against the sidebar border line. Now there's proper spacing on both sides.

## Test plan

- [x] Visual verification in browser
- [x] TypeScript type-check passing
- [x] ESLint passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)