### PR TITLE
feat: add completed vs upcoming funding round support

### DIFF
--- a/backend/src/worth_it/types.py
+++ b/backend/src/worth_it/types.py
@@ -15,12 +15,13 @@ class DilutionRound(TypedDict, total=False):
     """Configuration for a dilution funding round.
 
     Attributes:
-        year: The year when the dilution round occurs
+        year: The year when the dilution round occurs (negative = years ago for completed rounds)
         dilution: Percentage of dilution (0.0 to 1.0)
         new_salary: New monthly salary after this round (optional)
         is_safe_note: Whether this is a SAFE note (optional)
         valuation_at_sale: Valuation at time of secondary sale (optional)
         percent_to_sell: Percentage of equity to sell (optional, 0.0 to 1.0)
+        status: Round status - "completed" (past) or "upcoming" (future)
     """
 
     year: int
@@ -29,6 +30,7 @@ class DilutionRound(TypedDict, total=False):
     is_safe_note: bool
     valuation_at_sale: float
     percent_to_sell: float
+    status: str  # "completed" | "upcoming"
 
 
 class RSUParams(TypedDict, total=False):
@@ -39,12 +41,14 @@ class RSUParams(TypedDict, total=False):
         target_exit_valuation: Expected company valuation at exit
         simulate_dilution: Whether to simulate dilution rounds
         dilution_rounds: List of dilution round configurations
+        company_stage: Current stage of the company (pre-seed, seed, series-a, etc.)
     """
 
     equity_pct: float
     target_exit_valuation: float
     simulate_dilution: bool
     dilution_rounds: list[DilutionRound]
+    company_stage: str | None  # "pre-seed" | "seed" | "series-a" | "series-b" | "series-c" | "series-d" | "pre-ipo"
 
 
 class OptionsParams(TypedDict, total=False):

--- a/frontend/components/forms/company-stage-selector.tsx
+++ b/frontend/components/forms/company-stage-selector.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import * as React from "react";
+import { UseFormReturn } from "react-hook-form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Building2 } from "lucide-react";
+import type { CompanyStage, DilutionRoundForm } from "@/lib/schemas";
+import { DEFAULT_DILUTION_ROUNDS } from "@/lib/constants/funding-rounds";
+
+interface CompanyStageSelectorProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>;
+  onChange?: (stage: CompanyStage) => void;
+}
+
+/**
+ * Stage definitions with their completed rounds.
+ * When a stage is selected, all prior rounds are marked as "completed"
+ * and future rounds are marked as "upcoming".
+ */
+const STAGE_DEFINITIONS: Record<
+  CompanyStage,
+  {
+    label: string;
+    description: string;
+    completedRounds: string[];
+    typicalDilution: string;
+  }
+> = {
+  "pre-seed": {
+    label: "Pre-Seed",
+    description: "Just starting, no funding yet",
+    completedRounds: [],
+    typicalDilution: "0%",
+  },
+  seed: {
+    label: "Post-Seed",
+    description: "Seed round completed",
+    completedRounds: ["Pre-Seed", "Seed"],
+    typicalDilution: "~25%",
+  },
+  "series-a": {
+    label: "Post-Series A",
+    description: "Series A completed",
+    completedRounds: ["Pre-Seed", "Seed", "Series A"],
+    typicalDilution: "~40%",
+  },
+  "series-b": {
+    label: "Post-Series B",
+    description: "Series B completed",
+    completedRounds: ["Pre-Seed", "Seed", "Series A", "Series B"],
+    typicalDilution: "~52%",
+  },
+  "series-c": {
+    label: "Post-Series C",
+    description: "Series C completed",
+    completedRounds: ["Pre-Seed", "Seed", "Series A", "Series B", "Series C"],
+    typicalDilution: "~60%",
+  },
+  "series-d": {
+    label: "Post-Series D",
+    description: "Series D completed",
+    completedRounds: ["Pre-Seed", "Seed", "Series A", "Series B", "Series C", "Series D"],
+    typicalDilution: "~65%",
+  },
+  "pre-ipo": {
+    label: "Pre-IPO",
+    description: "Late stage, preparing for IPO",
+    completedRounds: ["Pre-Seed", "Seed", "Series A", "Series B", "Series C", "Series D"],
+    typicalDilution: "~70%",
+  },
+};
+
+/**
+ * Generates dilution rounds based on the selected company stage.
+ * Completed rounds get negative years (indicating they happened in the past).
+ * Upcoming rounds get positive years (future projections).
+ */
+function generateRoundsForStage(stage: CompanyStage): DilutionRoundForm[] {
+  const stageConfig = STAGE_DEFINITIONS[stage];
+  const completedRoundNames = new Set(stageConfig.completedRounds);
+
+  // Start with default rounds as template
+  const rounds: DilutionRoundForm[] = [];
+
+  // Add completed rounds with negative years
+  let completedYear = -completedRoundNames.size;
+  for (const defaultRound of DEFAULT_DILUTION_ROUNDS) {
+    if (completedRoundNames.has(defaultRound.round_name)) {
+      rounds.push({
+        ...defaultRound,
+        year: completedYear,
+        enabled: true,
+        status: "completed",
+      });
+      completedYear++;
+    }
+  }
+
+  // Add upcoming rounds with positive years
+  let upcomingYear = 1;
+  for (const defaultRound of DEFAULT_DILUTION_ROUNDS) {
+    if (!completedRoundNames.has(defaultRound.round_name)) {
+      rounds.push({
+        ...defaultRound,
+        year: upcomingYear,
+        enabled: false, // User can enable the ones they want to model
+        status: "upcoming",
+      });
+      upcomingYear++;
+    }
+  }
+
+  return rounds;
+}
+
+export function CompanyStageSelector({
+  form,
+  onChange,
+}: CompanyStageSelectorProps) {
+  const currentStage = form.watch("company_stage") as CompanyStage | undefined;
+
+  const handleStageChange = (value: string) => {
+    const stage = value as CompanyStage;
+    form.setValue("company_stage", stage);
+
+    // Generate and set the appropriate rounds for this stage
+    const rounds = generateRoundsForStage(stage);
+    form.setValue("dilution_rounds", rounds);
+
+    onChange?.(stage);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Building2 className="h-4 w-4 text-muted-foreground" />
+        <Label className="text-sm font-medium">Company Stage</Label>
+      </div>
+
+      <Select value={currentStage ?? ""} onValueChange={handleStageChange}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select current funding stage..." />
+        </SelectTrigger>
+        <SelectContent>
+          {(Object.entries(STAGE_DEFINITIONS) as [CompanyStage, typeof STAGE_DEFINITIONS[CompanyStage]][]).map(
+            ([stage, config]) => (
+              <SelectItem key={stage} value={stage}>
+                <div className="flex items-center justify-between w-full gap-4">
+                  <div>
+                    <span className="font-medium">{config.label}</span>
+                    <span className="text-muted-foreground ml-2 text-xs">
+                      {config.description}
+                    </span>
+                  </div>
+                </div>
+              </SelectItem>
+            )
+          )}
+        </SelectContent>
+      </Select>
+
+      {currentStage && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          <Badge variant="outline" className="text-xs">
+            {STAGE_DEFINITIONS[currentStage].completedRounds.length} completed round
+            {STAGE_DEFINITIONS[currentStage].completedRounds.length !== 1 ? "s" : ""}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            Typical dilution: {STAGE_DEFINITIONS[currentStage].typicalDilution}
+          </Badge>
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Selecting a stage will configure funding rounds automatically. Completed rounds
+        represent historical dilution; upcoming rounds are what you&apos;ll model.
+      </p>
+    </div>
+  );
+}
+
+export { generateRoundsForStage, STAGE_DEFINITIONS };

--- a/frontend/components/forms/completed-rounds-section.tsx
+++ b/frontend/components/forms/completed-rounds-section.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import * as React from "react";
+import { UseFormReturn } from "react-hook-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ChevronDown, ChevronUp, History, Edit2 } from "lucide-react";
+import { NumberInputField, SelectField } from "./form-fields";
+import type { DilutionRoundForm } from "@/lib/schemas";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { formatCurrency } from "@/lib/format-utils";
+
+interface CompletedRoundsSectionProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>;
+  completedRounds: DilutionRoundForm[];
+  completedRoundIndices: number[];
+}
+
+/**
+ * Displays completed (historical) funding rounds in a collapsed summary view.
+ * These represent rounds that already happened before the user joined.
+ */
+export function CompletedRoundsSection({
+  form,
+  completedRounds,
+  completedRoundIndices,
+}: CompletedRoundsSectionProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isEditing, setIsEditing] = React.useState(false);
+
+  if (completedRounds.length === 0) {
+    return null;
+  }
+
+  // Calculate total historical dilution
+  const totalHistoricalDilution = completedRounds.reduce((acc, round) => {
+    if (round.enabled) {
+      // Cumulative dilution: (1 - d1) * (1 - d2) * ...
+      return acc * (1 - round.dilution_pct / 100);
+    }
+    return acc;
+  }, 1);
+
+  const totalDilutionPct = ((1 - totalHistoricalDilution) * 100).toFixed(1);
+
+  // Calculate total raised
+  const totalRaised = completedRounds.reduce((acc, round) => {
+    if (round.enabled) {
+      return acc + round.amount_raised;
+    }
+    return acc;
+  }, 0);
+
+  return (
+    <Card className="border-muted bg-muted/30">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <History className="h-4 w-4 text-muted-foreground" />
+              <CardTitle className="text-sm font-medium">
+                Funding History
+              </CardTitle>
+              <Badge variant="secondary" className="text-xs">
+                {completedRounds.length} round{completedRounds.length !== 1 ? "s" : ""}
+              </Badge>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                  {isOpen ? (
+                    <ChevronUp className="h-4 w-4" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4" />
+                  )}
+                  <span className="sr-only">Toggle history</span>
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+          </div>
+
+          {/* Summary line always visible */}
+          <div className="flex flex-wrap gap-4 mt-2 text-sm text-muted-foreground">
+            <span>
+              Total dilution:{" "}
+              <span className="font-medium text-foreground">{totalDilutionPct}%</span>
+            </span>
+            <span>
+              Total raised:{" "}
+              <span className="font-medium text-foreground">
+                {formatCurrency(totalRaised)}
+              </span>
+            </span>
+          </div>
+        </CardHeader>
+
+        <CollapsibleContent>
+          <CardContent className="space-y-4 pt-0">
+            {/* Edit toggle */}
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setIsEditing(!isEditing)}
+                className="text-xs"
+              >
+                <Edit2 className="h-3 w-3 mr-1" />
+                {isEditing ? "Done Editing" : "Edit History"}
+              </Button>
+            </div>
+
+            {/* List of completed rounds */}
+            <div className="space-y-3">
+              {completedRounds.map((round, idx) => {
+                const originalIndex = completedRoundIndices[idx];
+                return (
+                  <CompletedRoundItem
+                    key={`${round.round_name}-${originalIndex}`}
+                    form={form}
+                    round={round}
+                    roundIndex={originalIndex}
+                    isEditing={isEditing}
+                  />
+                );
+              })}
+            </div>
+
+            {/* Explanation text */}
+            <p className="text-xs text-muted-foreground">
+              These rounds occurred before you joined. Your equity grant (
+              {form.watch("total_equity_grant_pct")}%) is already post-dilution from
+              these rounds.
+            </p>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+interface CompletedRoundItemProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>;
+  round: DilutionRoundForm;
+  roundIndex: number;
+  isEditing: boolean;
+}
+
+function CompletedRoundItem({
+  form,
+  round,
+  roundIndex,
+  isEditing,
+}: CompletedRoundItemProps) {
+  const yearsAgo = Math.abs(round.year);
+
+  if (!isEditing) {
+    // Read-only summary view
+    return (
+      <div className="flex items-center justify-between py-2 px-3 rounded-md bg-background/50">
+        <div className="flex items-center gap-3">
+          <Badge variant="outline" className="text-xs">
+            {round.round_name}
+          </Badge>
+          <span className="text-sm text-muted-foreground">
+            {yearsAgo} year{yearsAgo !== 1 ? "s" : ""} ago
+          </span>
+        </div>
+        <div className="flex items-center gap-4 text-sm">
+          <span>
+            <span className="text-muted-foreground">Dilution:</span>{" "}
+            <span className="font-medium">{round.dilution_pct}%</span>
+          </span>
+          <span>
+            <span className="text-muted-foreground">Raised:</span>{" "}
+            <span className="font-medium">{formatCurrency(round.amount_raised)}</span>
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Editable view
+  return (
+    <Card className="border-dashed">
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="text-xs">
+            {round.round_name}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            (Completed {yearsAgo} year{yearsAgo !== 1 ? "s" : ""} ago)
+          </span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <SelectField
+            form={form}
+            name={`dilution_rounds.${roundIndex}.round_type`}
+            label="Round Type"
+            options={[
+              { value: "SAFE_NOTE", label: "SAFE Note" },
+              { value: "PRICED_ROUND", label: "Priced Round" },
+            ]}
+          />
+
+          <NumberInputField
+            form={form}
+            name={`dilution_rounds.${roundIndex}.dilution_pct`}
+            label="Dilution %"
+            min={0}
+            max={100}
+            step={0.1}
+            suffix="%"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <NumberInputField
+            form={form}
+            name={`dilution_rounds.${roundIndex}.pre_money_valuation`}
+            label="Pre-Money Valuation"
+            min={0}
+            step={1000000}
+            prefix="$"
+            formatDisplay={true}
+          />
+
+          <NumberInputField
+            form={form}
+            name={`dilution_rounds.${roundIndex}.amount_raised`}
+            label="Amount Raised"
+            min={0}
+            step={1000000}
+            prefix="$"
+            formatDisplay={true}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/constants/examples.ts
+++ b/frontend/lib/constants/examples.ts
@@ -20,12 +20,16 @@ export interface ExampleScenario {
 /**
  * Pre-configured example scenarios for quick exploration.
  * Each represents a typical startup stage with realistic values.
+ *
+ * Funding rounds have a `status` field:
+ * - "completed": Past rounds that already happened (dilution applied to starting equity)
+ * - "upcoming": Future rounds that will dilute your equity going forward
  */
 export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
   {
     id: "early-stage",
     name: "Early-stage Startup (Seed)",
-    description: "$8K salary, 0.5% equity",
+    description: "$8K salary, 0.5% equity, joining post-Seed",
     stage: "early",
     globalSettings: {
       exit_year: 5,
@@ -43,7 +47,32 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
       vesting_period: 4,
       cliff_period: 1,
       simulate_dilution: true,
+      company_stage: "seed",
       dilution_rounds: [
+        // COMPLETED: Historical rounds (company already raised these)
+        {
+          round_name: "Pre-Seed",
+          round_type: "SAFE_NOTE",
+          year: -2,
+          dilution_pct: 10,
+          pre_money_valuation: 3000000,
+          amount_raised: 300000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Seed",
+          round_type: "SAFE_NOTE",
+          year: -1,
+          dilution_pct: 15,
+          pre_money_valuation: 8000000,
+          amount_raised: 1500000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        // UPCOMING: Future rounds to model
         {
           round_name: "Series A",
           round_type: "PRICED_ROUND",
@@ -53,6 +82,7 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
           amount_raised: 5000000,
           salary_change: 1000,
           enabled: true,
+          status: "upcoming",
         },
         {
           round_name: "Series B",
@@ -63,6 +93,7 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
           amount_raised: 15000000,
           salary_change: 2000,
           enabled: true,
+          status: "upcoming",
         },
       ],
       exit_valuation: 100000000,
@@ -71,7 +102,7 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
   {
     id: "growth-stage",
     name: "Growth-stage (Series B)",
-    description: "$12K salary, 0.1% equity",
+    description: "$12K salary, 0.1% equity, joining post-Series B",
     stage: "growth",
     globalSettings: {
       exit_year: 4,
@@ -89,7 +120,43 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
       vesting_period: 4,
       cliff_period: 1,
       simulate_dilution: true,
+      company_stage: "series-b",
       dilution_rounds: [
+        // COMPLETED: Historical rounds (company already raised these)
+        {
+          round_name: "Seed",
+          round_type: "SAFE_NOTE",
+          year: -3,
+          dilution_pct: 15,
+          pre_money_valuation: 8000000,
+          amount_raised: 1500000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series A",
+          round_type: "PRICED_ROUND",
+          year: -2,
+          dilution_pct: 20,
+          pre_money_valuation: 25000000,
+          amount_raised: 6000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series B",
+          round_type: "PRICED_ROUND",
+          year: -1,
+          dilution_pct: 18,
+          pre_money_valuation: 80000000,
+          amount_raised: 18000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        // UPCOMING: Future rounds to model
         {
           round_name: "Series C",
           round_type: "PRICED_ROUND",
@@ -99,6 +166,18 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
           amount_raised: 50000000,
           salary_change: 1500,
           enabled: true,
+          status: "upcoming",
+        },
+        {
+          round_name: "Series D",
+          round_type: "PRICED_ROUND",
+          year: 4,
+          dilution_pct: 10,
+          pre_money_valuation: 800000000,
+          amount_raised: 80000000,
+          salary_change: 2000,
+          enabled: false,
+          status: "upcoming",
         },
       ],
       exit_valuation: 500000000,
@@ -107,7 +186,7 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
   {
     id: "late-stage",
     name: "Late-stage (Pre-IPO)",
-    description: "$16K salary, 0.05% equity",
+    description: "$16K salary, 0.05% equity, joining pre-IPO",
     stage: "late",
     globalSettings: {
       exit_year: 2,
@@ -124,8 +203,67 @@ export const EXAMPLE_SCENARIOS: ExampleScenario[] = [
       total_equity_grant_pct: 0.05,
       vesting_period: 4,
       cliff_period: 1,
-      simulate_dilution: false,
-      dilution_rounds: [],
+      simulate_dilution: true,
+      company_stage: "pre-ipo",
+      dilution_rounds: [
+        // COMPLETED: Historical rounds (company already raised these)
+        {
+          round_name: "Seed",
+          round_type: "SAFE_NOTE",
+          year: -6,
+          dilution_pct: 15,
+          pre_money_valuation: 10000000,
+          amount_raised: 2000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series A",
+          round_type: "PRICED_ROUND",
+          year: -5,
+          dilution_pct: 20,
+          pre_money_valuation: 50000000,
+          amount_raised: 12000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series B",
+          round_type: "PRICED_ROUND",
+          year: -4,
+          dilution_pct: 18,
+          pre_money_valuation: 200000000,
+          amount_raised: 45000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series C",
+          round_type: "PRICED_ROUND",
+          year: -2,
+          dilution_pct: 15,
+          pre_money_valuation: 600000000,
+          amount_raised: 100000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        {
+          round_name: "Series D",
+          round_type: "PRICED_ROUND",
+          year: -1,
+          dilution_pct: 10,
+          pre_money_valuation: 1500000000,
+          amount_raised: 150000000,
+          salary_change: 0,
+          enabled: true,
+          status: "completed",
+        },
+        // UPCOMING: No more dilution expected before IPO
+      ],
       exit_valuation: 2000000000,
     },
   },

--- a/frontend/lib/constants/funding-rounds.ts
+++ b/frontend/lib/constants/funding-rounds.ts
@@ -33,6 +33,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 5_000_000, // SAR 5M
     amount_raised: 500_000, // SAR 500K
     salary_change: 0,
+    status: "upcoming",
   },
   {
     round_name: "Seed",
@@ -43,6 +44,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 8_000_000, // SAR 8M
     amount_raised: 1_500_000, // SAR 1.5M
     salary_change: 0,
+    status: "upcoming",
   },
   {
     round_name: "Series A",
@@ -53,6 +55,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 15_000_000, // SAR 15M
     amount_raised: 5_000_000, // SAR 5M
     salary_change: 0,
+    status: "upcoming",
   },
   {
     round_name: "Series B",
@@ -63,6 +66,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 40_000_000, // SAR 40M
     amount_raised: 10_000_000, // SAR 10M
     salary_change: 0,
+    status: "upcoming",
   },
   {
     round_name: "Series C",
@@ -73,6 +77,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 80_000_000, // SAR 80M
     amount_raised: 15_000_000, // SAR 15M
     salary_change: 0,
+    status: "upcoming",
   },
   {
     round_name: "Series D",
@@ -83,6 +88,7 @@ export const DEFAULT_DILUTION_ROUNDS: DilutionRoundForm[] = [
     pre_money_valuation: 150_000_000, // SAR 150M
     amount_raised: 20_000_000, // SAR 20M
     salary_change: 0,
+    status: "upcoming",
   },
 ];
 

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -18,6 +18,20 @@ export type InvestmentFrequency = z.infer<typeof InvestmentFrequencyEnum>;
 export const RoundTypeEnum = z.enum(["SAFE_NOTE", "PRICED_ROUND"]);
 export type RoundType = z.infer<typeof RoundTypeEnum>;
 
+export const RoundStatusEnum = z.enum(["completed", "upcoming"]);
+export type RoundStatus = z.infer<typeof RoundStatusEnum>;
+
+export const CompanyStageEnum = z.enum([
+  "pre-seed",
+  "seed",
+  "series-a",
+  "series-b",
+  "series-c",
+  "series-d",
+  "pre-ipo",
+]);
+export type CompanyStage = z.infer<typeof CompanyStageEnum>;
+
 // ============================================================================
 // Request Schemas
 // ============================================================================
@@ -187,12 +201,13 @@ export type CurrentJobForm = z.infer<typeof CurrentJobFormSchema>;
 export const DilutionRoundFormSchema = z.object({
   round_name: z.string(),
   round_type: RoundTypeEnum,
-  year: z.number().min(0).max(20),
+  year: z.number().min(-10).max(20), // Negative years = completed rounds (years ago)
   dilution_pct: z.number().min(0).max(100),
   pre_money_valuation: z.number().min(0),
   amount_raised: z.number().min(0),
   salary_change: z.number(),
   enabled: z.boolean(),
+  status: RoundStatusEnum.default("upcoming"), // NEW: completed = past, upcoming = future
 });
 export type DilutionRoundForm = z.infer<typeof DilutionRoundFormSchema>;
 
@@ -203,6 +218,7 @@ export const RSUFormSchema = z.object({
   vesting_period: z.number().int().min(1).max(10).default(4),
   cliff_period: z.number().int().min(0).max(5).default(1),
   simulate_dilution: z.boolean().default(false),
+  company_stage: CompanyStageEnum.optional(), // NEW: helps auto-configure rounds
   dilution_rounds: z.array(DilutionRoundFormSchema),
   exit_valuation: z.number().min(0),
 });


### PR DESCRIPTION
## Summary

- Add distinction between historical (completed) and future (upcoming) funding rounds for more accurate equity dilution modeling
- Completed rounds apply dilution from day 0 (representing dilution that happened before the employee joined)
- Upcoming rounds apply dilution starting from their specified year (future fundraising)
- Add company stage selector to help users configure appropriate funding history

## Changes

**Backend:**
- Separate completed and upcoming rounds in dilution calculation logic
- Apply historical dilution factor from year 0 for all completed rounds
- Add `status` field to DilutionRound type (`"completed"` | `"upcoming"`)
- Add `company_stage` field to RSUParams
- Add comprehensive test coverage for the new functionality

**Frontend:**
- New `CompanyStageSelector` component for selecting current company stage
- New `CompletedRoundsSection` component to display/edit historical rounds
- Refactor RSU form to show completed and upcoming rounds in separate sections
- Update Zod schemas with new fields
- Update example scenarios with realistic historical funding rounds

## Test plan

- [x] Backend unit tests pass (`uv run pytest -v`)
- [ ] Frontend type check passes (`npm run type-check`)
- [ ] Frontend lint passes (`npm run lint`)
- [ ] Manual testing of the dilution calculator with various round configurations
- [ ] Verify completed rounds apply dilution from year 0
- [ ] Verify upcoming rounds apply dilution from their specified year

🤖 Generated with [Claude Code](https://claude.com/claude-code)