### PR TITLE
feat(ui): simplify Monte Carlo visualization default view (#133)

### DIFF
--- a/frontend/__tests__/components/charts/monte-carlo-visualizations.test.tsx
+++ b/frontend/__tests__/components/charts/monte-carlo-visualizations.test.tsx
@@ -190,6 +190,27 @@ describe("MonteCarloVisualizations - Simplified View", () => {
       );
     });
 
+    it("saves collapsed preference to localStorage when toggling back", async () => {
+      const user = userEvent.setup();
+      render(
+        <MonteCarloVisualizations
+          netOutcomes={mockNetOutcomes}
+          simulatedValuations={mockSimulatedValuations}
+        />
+      );
+
+      // Expand first
+      await user.click(screen.getByRole("button", { name: /see detailed analysis/i }));
+
+      // Then collapse
+      await user.click(screen.getByRole("button", { name: /hide detailed analysis/i }));
+
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+        "monte-carlo-expanded",
+        "false"
+      );
+    });
+
     it("restores expanded state from localStorage on mount", () => {
       localStorageMock.getItem.mockReturnValue("true");
 
@@ -206,8 +227,8 @@ describe("MonteCarloVisualizations - Simplified View", () => {
   });
 
   describe("Plain-English Summary", () => {
-    it("shows positive outcome message when success rate >= 70%", () => {
-      // Create data with high positive rate
+    it("shows 'Strong outlook' message when success rate >= 70%", () => {
+      // Create data with high positive rate (80%)
       const highPositiveOutcomes = Array.from({ length: 100 }, (_, i) =>
         i < 80 ? 50000 + Math.random() * 100000 : -10000 - Math.random() * 20000
       );
@@ -219,10 +240,12 @@ describe("MonteCarloVisualizations - Simplified View", () => {
         />
       );
 
-      expect(screen.getByTestId("monte-carlo-headline")).toHaveTextContent(/chance.*positive/i);
+      const headline = screen.getByTestId("monte-carlo-headline");
+      expect(headline).toHaveTextContent(/strong outlook/i);
+      expect(headline).toHaveTextContent(/chance.*positive/i);
     });
 
-    it("shows moderate risk message when success rate is 50-70%", () => {
+    it("shows 'Moderate outlook' message when success rate is 50-70%", () => {
       // Create data with moderate positive rate (~60%)
       const moderateOutcomes = Array.from({ length: 100 }, (_, i) =>
         i < 60 ? 50000 + Math.random() * 100000 : -10000 - Math.random() * 50000
@@ -235,10 +258,12 @@ describe("MonteCarloVisualizations - Simplified View", () => {
         />
       );
 
-      expect(screen.getByTestId("monte-carlo-headline")).toBeInTheDocument();
+      const headline = screen.getByTestId("monte-carlo-headline");
+      expect(headline).toHaveTextContent(/moderate outlook/i);
+      expect(headline).toHaveTextContent(/chance.*positive/i);
     });
 
-    it("shows caution message when success rate < 50%", () => {
+    it("shows 'Caution' message when success rate < 50%", () => {
       // Create data with low positive rate (~30%)
       const lowPositiveOutcomes = Array.from({ length: 100 }, (_, i) =>
         i < 30 ? 50000 + Math.random() * 100000 : -10000 - Math.random() * 50000
@@ -251,7 +276,9 @@ describe("MonteCarloVisualizations - Simplified View", () => {
         />
       );
 
-      expect(screen.getByTestId("monte-carlo-headline")).toBeInTheDocument();
+      const headline = screen.getByTestId("monte-carlo-headline");
+      expect(headline).toHaveTextContent(/caution/i);
+      expect(headline).toHaveTextContent(/only.*%.*chance/i);
     });
   });
 });

--- a/frontend/components/charts/monte-carlo-visualizations.tsx
+++ b/frontend/components/charts/monte-carlo-visualizations.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { ChevronDown, ChevronUp, TrendingUp, TrendingDown, Target } from "lucide-react";
+import { ChevronDown, ChevronUp, TrendingUp, TrendingDown, Target, ArrowLeftRight } from "lucide-react";
 import {
   MonteCarloHistogram,
   MonteCarloEcdf,
@@ -71,11 +71,11 @@ export function MonteCarloVisualizations({
   const headline = React.useMemo(() => {
     const successPct = Math.round(stats.positiveRate);
     if (stats.positiveRate >= 70) {
-      return `${successPct}% chance of a positive outcome`;
+      return `Strong outlook: ${successPct}% chance of a positive outcome`;
     } else if (stats.positiveRate >= 50) {
-      return `${successPct}% chance of a positive outcome`;
+      return `Moderate outlook: ${successPct}% chance of a positive outcome`;
     } else {
-      return `${successPct}% chance of a positive outcome`;
+      return `Caution: only ${successPct}% chance of a positive outcome`;
     }
   }, [stats.positiveRate]);
 
@@ -178,7 +178,8 @@ export function MonteCarloVisualizations({
           </div>
           <div className="bg-muted/50 rounded-lg p-4 flex flex-col items-center">
             <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
-              <span>Range</span>
+              <ArrowLeftRight className="h-4 w-4" />
+              <span>Outcome Range</span>
             </div>
             <span className="text-xl font-semibold tabular-nums">
               {formatCurrency(stats.min)} to {formatCurrency(stats.max)}
@@ -186,13 +187,15 @@ export function MonteCarloVisualizations({
           </div>
         </div>
 
-        {/* Histogram Section (always visible) */}
-        <div className="space-y-2">
-          <h3 className="text-sm font-medium text-muted-foreground">
-            Distribution of Outcomes
-          </h3>
-          <MonteCarloHistogram data={histogramData} />
-        </div>
+        {/* Histogram Section (visible only when collapsed to avoid duplication) */}
+        {!isExpanded && (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              Distribution of Outcomes
+            </h3>
+            <MonteCarloHistogram data={histogramData} />
+          </div>
+        )}
 
         {/* Expand/Collapse Button */}
         <div className="flex justify-center">


### PR DESCRIPTION
## Summary
Implements issue #133 - Simplify Monte Carlo visualization default view.

**Changes:**
- Add progressive disclosure pattern to Monte Carlo Results
- Show simplified view by default: headline + summary cards + histogram
- Add "See detailed analysis" button to expand all 7 visualization tabs
- Persist user preference in localStorage

## Before vs After

### Before
- All 7 tabs visible immediately (overwhelming for non-technical users)
- No summary headline

### After - Default Collapsed View
- Plain-English summary headline: "X% chance of a positive outcome"
- 3 metric summary cards: Expected Value, Success Probability, Range
- Histogram visualization always visible
- "See detailed analysis" button to expand

### After - Expanded View
- All 7 tabs: Histogram, ECDF, Box Plot, Scatter, Statistics, PDF, Summary
- "Hide detailed analysis" button to collapse
- State persisted in localStorage

## Test Plan
- [x] Added 15 new unit tests for:
  - Default collapsed view behavior
  - Expanded view tab visibility
  - Toggle button text changes
  - localStorage persistence
  - Plain-English summary messaging
- [x] All 703 frontend tests pass
- [x] TypeScript type check passes
- [x] ESLint passes

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)